### PR TITLE
madmin: Fix issues in storage-class helper functions

### DIFF
--- a/pkg/madmin/storage-class-config.go
+++ b/pkg/madmin/storage-class-config.go
@@ -70,7 +70,7 @@ func (cfg *TransitionStorageClassConfig) Endpoint() string {
 	case Azure:
 		return cfg.Azure.Endpoint
 	case GCS:
-		return cfg.Azure.Endpoint
+		return cfg.GCS.endpoint
 	}
 	log.Printf("unexpected transition storage-class type %s", cfg.Type)
 	return ""
@@ -83,7 +83,7 @@ func (cfg *TransitionStorageClassConfig) Bucket() string {
 	case Azure:
 		return cfg.Azure.Bucket
 	case GCS:
-		return cfg.Azure.Bucket
+		return cfg.GCS.Bucket
 	}
 	log.Printf("unexpected transition storage-class type %s", cfg.Type)
 	return ""

--- a/pkg/madmin/storage-class-gcs.go
+++ b/pkg/madmin/storage-class-gcs.go
@@ -21,7 +21,7 @@ import "encoding/base64"
 
 type TransitionStorageClassGCS struct {
 	Name     string
-	Endpoint string
+	endpoint string // custom endpoint is not supported for GCS
 	Creds    string // base64 encoding of credentials.json FIXME: TBD how do we persist gcs creds file
 	Bucket   string
 	Prefix   string
@@ -44,13 +44,6 @@ func GCSRegion(region string) func(*TransitionStorageClassGCS) error {
 	}
 }
 
-func GCSEndpoint(endpoint string) func(*TransitionStorageClassGCS) error {
-	return func(gcs *TransitionStorageClassGCS) error {
-		gcs.Endpoint = endpoint
-		return nil
-	}
-}
-
 func (gcs *TransitionStorageClassGCS) GetCredentialJSON() ([]byte, error) {
 	return base64.URLEncoding.DecodeString(gcs.Creds)
 }
@@ -62,8 +55,9 @@ func NewTransitionStorageClassGCS(name string, credsJSON []byte, bucket string, 
 		Creds:  creds,
 		Bucket: bucket,
 		// Defaults
-		Prefix: "",
-		Region: "",
+		endpoint: "https://storage.googleapis.com/storage/v1/", // endpoint is meant only for client-side display purposes
+		Prefix:   "",
+		Region:   "",
 	}
 
 	for _, option := range options {

--- a/pkg/madmin/storage-class_test.go
+++ b/pkg/madmin/storage-class_test.go
@@ -61,7 +61,7 @@ func ExampleTransitionStorageClassGCS() {
 	}
 	fmt.Println(simpleGCSSC)
 
-	fullyCustomGCSSC, err := NewTransitionStorageClassGCS("custom-gcs", credsJSON, "testbucket", GCSEndpoint("https://storage.googleapis.com/storage/v1/"), GCSPrefix("testprefix"))
+	fullyCustomGCSSC, err := NewTransitionStorageClassGCS("custom-gcs", credsJSON, "testbucket", GCSPrefix("testprefix"))
 	if err != nil {
 		log.Fatalln(err, "Failed to create GCS backed storage-class")
 	}
@@ -129,7 +129,7 @@ func TestAzStorageClass(t *testing.T) {
 	}
 	got, err := NewTransitionStorageClassAzure(scName, accessKey, secretKey, bucket, options...)
 	if err != nil {
-		t.Fatalf("Failed to create a custom s3 transition storage class %s", err)
+		t.Fatalf("Failed to create a custom azure transition storage class %s", err)
 	}
 
 	if *got != *want {
@@ -140,7 +140,6 @@ func TestAzStorageClass(t *testing.T) {
 // TestGCSStorageClass tests GCSOptions helpers
 func TestGCSStorageClass(t *testing.T) {
 	scName := "test-gcs"
-	endpoint := "https://mygcs.com"
 	credsJSON := []byte("test-creds-json")
 	encodedCreds := base64.URLEncoding.EncodeToString(credsJSON)
 	bucket, prefix := "testbucket", "testprefix"
@@ -151,18 +150,17 @@ func TestGCSStorageClass(t *testing.T) {
 		Creds:  encodedCreds,
 
 		// custom values
-		Endpoint: endpoint,
+		endpoint: "https://storage.googleapis.com/storage/v1/",
 		Prefix:   prefix,
 		Region:   region,
 	}
 	options := []GCSOptions{
-		GCSEndpoint(endpoint),
 		GCSRegion(region),
 		GCSPrefix(prefix),
 	}
 	got, err := NewTransitionStorageClassGCS(scName, credsJSON, bucket, options...)
 	if err != nil {
-		t.Fatalf("Failed to create a custom s3 transition storage class %s", err)
+		t.Fatalf("Failed to create a custom gcs transition storage class %s", err)
 	}
 
 	if *got != *want {


### PR DESCRIPTION
- Also remove custom endpoint for GCS, since the Go SDK supports setting custom
endpoint via env vars only. This means MinIO can't support multiple
storage-classes backed by GCS as the env var would confuse the SDK.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.